### PR TITLE
Nosana node troubleshoot docs update - Error: container create failed (no logs from conmon)...

### DIFF
--- a/docs/nodes/testgrid-ubuntu.md
+++ b/docs/nodes/testgrid-ubuntu.md
@@ -181,8 +181,8 @@ curl http://localhost:8080/v4.5.0/libpod/info
 
 You can manually launch the Nosana Node to modify certain parameters:
 
-- Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
-- Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
+* Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
+* Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
 
 ```shell
 docker run \

--- a/docs/nodes/testgrid-ubuntu.md
+++ b/docs/nodes/testgrid-ubuntu.md
@@ -61,7 +61,6 @@ Example output:
 ### Guide to Install NVIDIA Container Toolkit
 
 To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands:
-
 ```shell
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
@@ -70,9 +69,7 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
   && \
     sudo apt-get update
 ```
-
 Then we can install the NVIDIA Container Toolkit package:
-
 ```shell
 sudo apt-get install -y nvidia-container-toolkit
 ```
@@ -128,7 +125,6 @@ You will see your node's information displayed in the following format. As long 
 Upon successful completion of the Test Grid benchmark job, you will receive a code in the logs. This code is required for your registration. Please follow the steps below:
 
 1. Check the logs for the following message:
-
    ```
    Job Succeeded: https://explorer.nosana.io/jobs/<JOB_ID>?network=devnet
    Test Grid Registration code: <CODE>
@@ -170,7 +166,6 @@ podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable ubuntu 
 If unsuccessful, ensure NVIDIA drivers and the nvidia-ctk are [installed](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) and [configured](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-docker)
 
 If you see `Error: container create failed (no logs from conmon)...` when running the command, follow the steps [here](/nodes/troubleshoot.html#podman) to resolve issue
-
 To validate Podman's proper functioning, use:
 
 ```shell
@@ -180,7 +175,6 @@ curl http://localhost:8080/v4.5.0/libpod/info
 ## Launching the Nosana Node with Custom Parameters
 
 You can manually launch the Nosana Node to modify certain parameters:
-
 * Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
 * Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
 

--- a/docs/nodes/testgrid-ubuntu.md
+++ b/docs/nodes/testgrid-ubuntu.md
@@ -60,7 +60,8 @@ Example output:
 
 ### Guide to Install NVIDIA Container Toolkit
 
-To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands: 
+To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands:
+
 ```shell
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
@@ -69,7 +70,9 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
   && \
     sudo apt-get update
 ```
+
 Then we can install the NVIDIA Container Toolkit package:
+
 ```shell
 sudo apt-get install -y nvidia-container-toolkit
 ```
@@ -125,6 +128,7 @@ You will see your node's information displayed in the following format. As long 
 Upon successful completion of the Test Grid benchmark job, you will receive a code in the logs. This code is required for your registration. Please follow the steps below:
 
 1. Check the logs for the following message:
+
    ```
    Job Succeeded: https://explorer.nosana.io/jobs/<JOB_ID>?network=devnet
    Test Grid Registration code: <CODE>
@@ -165,6 +169,8 @@ podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable ubuntu 
 
 If unsuccessful, ensure NVIDIA drivers and the nvidia-ctk are [installed](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) and [configured](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-docker)
 
+If you see `Error: container create failed (no logs from conmon)...` when running the command, follow the steps [here](/nodes/troubleshoot.html#podman) to resolve issue
+
 To validate Podman's proper functioning, use:
 
 ```shell
@@ -174,8 +180,9 @@ curl http://localhost:8080/v4.5.0/libpod/info
 ## Launching the Nosana Node with Custom Parameters
 
 You can manually launch the Nosana Node to modify certain parameters:
-* Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
-* Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
+
+- Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
+- Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
 
 ```shell
 docker run \
@@ -189,4 +196,5 @@ docker run \
 ```
 
 ## Troubleshoot
+
 If you have questions or when you have error messages, please take a look at our [Troubleshoot Guide](/nodes/troubleshoot) or join our [Discord](https://discord.gg/nosana) for help.

--- a/docs/nodes/testgrid-ubuntu.md
+++ b/docs/nodes/testgrid-ubuntu.md
@@ -60,7 +60,7 @@ Example output:
 
 ### Guide to Install NVIDIA Container Toolkit
 
-To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands:
+To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands: 
 ```shell
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
@@ -190,5 +190,4 @@ docker run \
 ```
 
 ## Troubleshoot
-
 If you have questions or when you have error messages, please take a look at our [Troubleshoot Guide](/nodes/troubleshoot) or join our [Discord](https://discord.gg/nosana) for help.

--- a/docs/nodes/testgrid-windows.md
+++ b/docs/nodes/testgrid-windows.md
@@ -205,8 +205,8 @@ curl http://localhost:8080/v4.5.0/libpod/info
 
 You can manually launch the Nosana Node to modify certain parameters:
 
-- Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
-- Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
+* Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
+* Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
 
 ```shell
 docker run \

--- a/docs/nodes/testgrid-windows.md
+++ b/docs/nodes/testgrid-windows.md
@@ -38,7 +38,6 @@ To ensure a successful setup, follow these steps to install and configure Docker
 
 2. After installation, make sure Docker is added to its own user group.
 
-
 ## NVIDIA
 
 To fully utilize the GPU on the grid, we will need to install both the NVIDIA drivers and NVIDIA's CUDA Toolkit.
@@ -77,14 +76,12 @@ If the drivers are correctly installed, you should see detailed information abou
 +-----------------------------------------------------------------------------+
 ```
 
-
-
-
 These commands will help you generate the necessary configuration file and verify the CDI support.
 
 ### Install the NVIDIA Container Toolkit
 
-To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands: 
+To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands:
+
 ```shell
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
@@ -93,7 +90,9 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
   && \
     sudo apt-get update
 ```
+
 Then we can install the NVIDIA Container Toolkit package:
+
 ```shell
 sudo apt-get install -y nvidia-container-toolkit
 ```
@@ -132,6 +131,7 @@ podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable ubuntu 
 
 If this doesn't work, make sure you have the NVIDIA drivers installed and the nvidia-ctk [installed](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) and [configured](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html)
 
+If you see `Error: container create failed (no logs from conmon)...` when running the command, follow the steps [here](/nodes/troubleshoot.html#podman) to resolve issue
 
 ## Nosana Test Grid Script
 
@@ -163,12 +163,12 @@ You will see your node's information displayed in the following format. As long 
   Owned      0 NFT
 ```
 
-
 ### Test Grid Registration Instructions
 
 Upon successful completion of the Test Grid benchmark job, you will receive a code in the logs. This code is required for your registration. Please follow the steps below:
 
 1. Check the logs for the following message:
+
    ```
    Job Succeeded: https://explorer.nosana.io/jobs/<JOB_ID>?network=devnet
    Test Grid Registration code: <CODE>
@@ -204,8 +204,9 @@ curl http://localhost:8080/v4.5.0/libpod/info
 ## Launching the Nosana Node with Custom Parameters
 
 You can manually launch the Nosana Node to modify certain parameters:
-* Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
-* Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
+
+- Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
+- Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
 
 ```shell
 docker run \
@@ -219,4 +220,5 @@ docker run \
 ```
 
 ## Troubleshoot
+
 If you have questions or when you have error messages, please take a look at our [Troubleshoot Guide](/nodes/troubleshoot) or join our [Discord](https://discord.gg/nosana) for help.

--- a/docs/nodes/testgrid-windows.md
+++ b/docs/nodes/testgrid-windows.md
@@ -38,6 +38,7 @@ To ensure a successful setup, follow these steps to install and configure Docker
 
 2. After installation, make sure Docker is added to its own user group.
 
+
 ## NVIDIA
 
 To fully utilize the GPU on the grid, we will need to install both the NVIDIA drivers and NVIDIA's CUDA Toolkit.
@@ -76,12 +77,14 @@ If the drivers are correctly installed, you should see detailed information abou
 +-----------------------------------------------------------------------------+
 ```
 
+
+
+
 These commands will help you generate the necessary configuration file and verify the CDI support.
 
 ### Install the NVIDIA Container Toolkit
 
 To install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) (`nvidia-ctk`), run the following commands:
-
 ```shell
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
@@ -90,9 +93,7 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
   && \
     sudo apt-get update
 ```
-
 Then we can install the NVIDIA Container Toolkit package:
-
 ```shell
 sudo apt-get install -y nvidia-container-toolkit
 ```
@@ -163,12 +164,12 @@ You will see your node's information displayed in the following format. As long 
   Owned      0 NFT
 ```
 
+
 ### Test Grid Registration Instructions
 
 Upon successful completion of the Test Grid benchmark job, you will receive a code in the logs. This code is required for your registration. Please follow the steps below:
 
 1. Check the logs for the following message:
-
    ```
    Job Succeeded: https://explorer.nosana.io/jobs/<JOB_ID>?network=devnet
    Test Grid Registration code: <CODE>
@@ -204,7 +205,6 @@ curl http://localhost:8080/v4.5.0/libpod/info
 ## Launching the Nosana Node with Custom Parameters
 
 You can manually launch the Nosana Node to modify certain parameters:
-
 * Use the `--podman` parameter to direct to your Podman service if it's running elsewhere.
 * Use `--volume` to map your solana key to `/root/.nosana/nosana_key.json` within the Docker container if you wish to use your own key.
 
@@ -220,5 +220,4 @@ docker run \
 ```
 
 ## Troubleshoot
-
 If you have questions or when you have error messages, please take a look at our [Troubleshoot Guide](/nodes/troubleshoot) or join our [Discord](https://discord.gg/nosana) for help.

--- a/docs/nodes/troubleshoot.md
+++ b/docs/nodes/troubleshoot.md
@@ -1,37 +1,50 @@
 # Troubleshooting Guide
+
 This guide is created to aid users in resolving issues with their GPU-equipped Nosana Node configuration on both Linux and Windows operating systems.
 
 ## Error Messages
+
+### Nvidia
+
 ::: warning nvidia-smi: command not found
 ::: details Solution
 It means that you do not have NVIDIA drivers installed. To install them, download and install the correct drivers from the NVIDIA website: https://www.nvidia.com/download/index.aspx
 :::
+
+::: warning Error: setting up CDI devices: unresolvable CDI devices nvidia.com/gpu=all
+::: details Solution
+It means that you did not install and configure the Nvidia Container Toolkit correctly:
+
+- [Nvidia instruction for WSL2 (Windows)](https://docs.nosana.io/nodes/testgrid-windows.html#install-the-nvidia-container-toolkit)
+- [Nvidia instructions for Ubuntu (Native)](https://docs.nosana.io/nodes/testgrid-ubuntu.html#guide-to-install-nvidia-container-toolkit)
+  :::
+
+### Docker
 
 ::: warning The command 'docker' could not be found in this WSL 2 distro.
 ::: details Solution
 Ensure that you have [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/) installed and that it is running. If you still have this error message, check if Docker Desktop is using the WSL2 Backend (not Hyper-V). Follow this guide to turn on the WSL2 backend for Docker Desktop: https://docs.docker.com/desktop/wsl/.
 
 Also check with Command Prompt or Powershell to make sure you have WSL version 2 installed:
+
 ```
 wsl -l -v
 ```
+
 Also make sure your Ubuntu 22.04 distro is the default WSL distribution. The Docker-WSL integration is enabled on the default WSL distribution. To change your default WSL distro, run:
 
 ```
 wsl --set-default <distro name>
 ```
+
 :::
 
-::: warning Error: setting up CDI devices: unresolvable CDI devices nvidia.com/gpu=all
-::: details Solution
-It means that you did not install and configure the Nvidia Container Toolkit correctly: 
-* [Nvidia instruction for WSL2 (Windows)](https://docs.nosana.io/nodes/testgrid-windows.html#install-the-nvidia-container-toolkit)
-* [Nvidia instructions for Ubuntu (Native)](https://docs.nosana.io/nodes/testgrid-ubuntu.html#guide-to-install-nvidia-container-toolkit)
-:::
+### Podman
 
 ::: warning Error: Could not connect to Podman
 ::: details Solution
 When you see this error go in Docker Desktop to -> Settings -> Docker engine, please add this line `"bip":"192.168.200.1/24",` somewhere after the first bracket, like this:
+
 ```
 {
   "bip":"192.168.200.1/24",
@@ -39,3 +52,19 @@ When you see this error go in Docker Desktop to -> Settings -> Docker engine, pl
 ```
 
 Then click appy and restart Docker.
+:::
+
+::: warning Error: container create failed (no logs from conmon): conmon bytes "": readObjectStart: expect { or n, but found , error found in #0 byte of ...||..., bigger context ...||...
+::: details Solution
+This error is caused by the latest version of `conmon` having known issues, downgrade `conmon` to resolve this, like this:
+
+```
+wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
+sudo apt install /tmp/conmon_2.1.2.deb
+```
+
+Then you can rerun the podmon command
+
+```
+podman run --rm --device nvidia.com/gpu=all --security-opt=label=disable ubuntu nvidia-smi -L
+```


### PR DESCRIPTION
This pull request is aimed at adding a quick solution for the latest version of `conmon` and the required downgrade to the troubleshooting docs as this has been a common theme within the discord channel today.

The solution currently presented and commonly accepted is to downgrade the pack to a previous stable version (v2.1.2) using the following commands:
```
wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
sudo apt install /tmp/conmon_2.1.2.deb
```

I have also added hyperlinks from the Windows and Ubuntu run pages, as well as grouping the troubleshooting issues, for better hyperlinking.