### PR TITLE
Resolve docker desktop bip format error

### DIFF
--- a/docs/nodes/troubleshoot.md
+++ b/docs/nodes/troubleshoot.md
@@ -52,6 +52,11 @@ When you see this error go in Docker Desktop to -> Settings -> Docker engine, pl
 ```
 
 Then click appy and restart Docker.
+
+***Error /bip must match format 1pv4***
+
+If you see this error using the latest version of Docker Desktop, downgrade to version `4.21.0`.
+
 :::
 
 ::: warning Error: container create failed (no logs from conmon): conmon bytes "": readObjectStart: expect { or n, but found , error found in #0 byte of ...||..., bigger context ...||...


### PR DESCRIPTION
The latest Docker Desktop versions have broken bip format validation. The simplest solution found is to downgrade the docker desktop to version 4.21.0. I've updated the troubleshooting docs to document this.

![image](https://github.com/nosana-ci/docs.nosana.io/assets/11080797/4bc5e27f-03c3-4e2c-82ec-36557bdab5f2)

Docker Desktop for-mac Github issue - https://github.com/docker/for-mac/issues/7104