### PR TITLE
Fix typo in docs/protocols/start.md

### DIFF
--- a/docs/protocols/start.md
+++ b/docs/protocols/start.md
@@ -1,5 +1,5 @@
 # Getting Started
 
-The Nosana programs, powered by Solana, offer a variety of protocols that users can take advantage of. With the [Nosana Token](token), users can [stake](stakink), earn [rewards](rewards), participate in the open [compute market](jobs), register [nodes](nodes), and join vesting [pools](pools).
+The Nosana programs, powered by Solana, offer a variety of protocols that users can take advantage of. With the [Nosana Token](token), users can [stake](staking), earn [rewards](rewards), participate in the open [compute market](jobs), register [nodes](nodes), and join vesting [pools](pools).
 
 Find code examples and documentation to start using the Nosana Network. In the following pages, we will provide an in-depth explanation of each of the protocols.


### PR DESCRIPTION
This pull request fixes the typo which resolves to an incorrect link within the docs. Changed "stakink" to "staking" when clicking the word stake in docs/protocols/start.md.